### PR TITLE
Bug fixes for scaling arguments

### DIFF
--- a/R/irlba.R
+++ b/R/irlba.R
@@ -308,8 +308,12 @@ function(A,                     # data matrix
 # Check for tiny problem, use standard SVD in that case. Make definition of 'tiny' larger?
   if (min(m, n) < 6)
   {
+    A <- as.matrix(A) # avoid need to define "+" and "/" for arbitrary matrix types.
     if (verbose) message("Tiny problem detected, using standard `svd` function.")
-    if (!is.null(scale)) A <- A / scale
+    if (!is.null(scale)) {
+      A <- sweep(A, 2, scale, "/")
+      dv <- dv / scale # scale the centering vector.
+    }
     if (!is.null(shift)) A <- A + diag(shift, nrow(A), ncol(A))
     if (deflate)
     {

--- a/R/irlba.R
+++ b/R/irlba.R
@@ -544,7 +544,11 @@ Use `set.seed` first for reproducibility.")
 #     Optionally apply shift, scale, deflate
       if (!is.null(shift)) F <- F + shift * W[, j_w]
       if (!is.null(scale)) F <- F / scale
-      if (deflate) F <- F - sum(W[, j_w]) * dv
+      if (deflate) {
+        sub <- sum(W[, j_w]) * dv
+        if (!is.null(scale)) sub <- sub / scale
+        F <- F - sub
+      }
       mprod <- mprod + 1
       F <- drop(F - S * V[, j])
 #     Orthogonalize


### PR DESCRIPTION
The first commit fixes the following behaviour in the tiny problem case:

```r
set.seed(0)
A <- matrix(runif(10), 5, 4)
center <- runif(4)
scale <- runif(4)

library(irlba)
X <- irlba(A, nv=3, nu=3, center=center, scale=scale)
X$d
# [1] 4.4874209 2.7501384 0.5115381
A2 <- scale(A, center=center, scale=scale)
ref <- irlba(A2, nv=3, nu=3)
ref$d
# [1] 4.2779403 1.4405317 0.2149879
```

The fix ensures that the first call gives the same results as the second reference call.

The second commit fixes the problem described in #42; the first call is now the same as the second.

Some points:
- Probably worth putting these checks for equality in the unit tests somewhere.
- The `fastpath=TRUE` case for #42 is not fixed, I didn't want to mess with the C code.

<details>
<summary>Session information</summary>

```
R Under development (unstable) (2018-11-02 r75535)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: Ubuntu 16.04.5 LTS

Matrix products: default
BLAS: /home/cri.camres.org/lun01/Software/R/trunk/lib/libRblas.so
LAPACK: /home/cri.camres.org/lun01/Software/R/trunk/lib/libRlapack.so

locale:
 [1] LC_CTYPE=en_GB.UTF-8       LC_NUMERIC=C              
 [3] LC_TIME=en_GB.UTF-8        LC_COLLATE=en_GB.UTF-8    
 [5] LC_MONETARY=en_GB.UTF-8    LC_MESSAGES=en_GB.UTF-8   
 [7] LC_PAPER=en_GB.UTF-8       LC_NAME=C                 
 [9] LC_ADDRESS=C               LC_TELEPHONE=C            
[11] LC_MEASUREMENT=en_GB.UTF-8 LC_IDENTIFICATION=C       

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] irlba_2.3.3   Matrix_1.2-15

loaded via a namespace (and not attached):
[1] compiler_3.6.0  grid_3.6.0      lattice_0.20-38
```
</details>