### PR TITLE
Generalized code to non-vector matrix products.

### DIFF
--- a/R/irlba.R
+++ b/R/irlba.R
@@ -487,13 +487,9 @@ Use `set.seed` first for reproducibility.")
     }
     if (interchange) avj <- mult(VJ, A)
     else avj <- mult(A, VJ)
-#   Handle sparse products.
-    if ("Matrix" %in% attributes(class(avj)) && "x" %in% slotNames(avj))
-    {
-      if (length(avj@x) == nrow(W)) avj <- slot(avj, "x")
-      else avj <- as.vector(avj)
-    }
-    W[, j_w] <- avj
+
+#   Handle non-ordinary arrays as products.
+    W[, j_w] <- as.vector(avj)
     mprod <- mprod + 1
 
 #   Optionally apply shift


### PR DESCRIPTION
This coerces the product of `A %*% VJ` into a vector, regardless of its original class. This generalizes the behaviour for _Matrix_ classes with an `"x"` slot (presumably `dgCMatrix` instances?) to other matrix representations - for example, we've been using it with [_DelayedArray_ objects](https://github.com/Bioconductor/DelayedArray).

