### PR TITLE
Fix for scaling with alternative matrices

### DIFF
--- a/R/irlba.R
+++ b/R/irlba.R
@@ -453,6 +453,9 @@ Use `set.seed` first for reproducibility.")
     V[, k + 1] <- F / norm2(F)
   }
 
+# Change du to be non-NULL, for non-fastpath'able matrices with non-NULL scale.
+  if (deflate && is.null(du)) du <- 1
+
 # ---------------------------------------------------------------------
 # Main iteration
 # ---------------------------------------------------------------------

--- a/tests/test.R
+++ b/tests/test.R
@@ -208,3 +208,15 @@ if (!isTRUE(all.equal(L$d, tail(svd(x)$d, 5))))
 {
   stop("Failed smallest svd test")
 }
+
+# test for https://github.com/bwlewis/irlba/issues/47 (again, fastpath always FALSE)
+set.seed(2345)
+a <- spMatrix(50, 40, x=runif(200), i=sample(50, 200, replace=TRUE), j=sample(40, 200, replace=TRUE))
+center <- runif(ncol(a))
+scale <- runif(ncol(a))
+L <- irlba(a, 5, scale=scale, center=center)
+S <- svd(scale(a, center=center, scale=scale))
+if (isTRUE(max(abs(S$d[1:5] - L$d)) > 1e-3))
+{
+  stop("Failed scale + center test for non-fastpath'able matrices")
+}


### PR DESCRIPTION
Ostensibly fixes #47, but the same fix should apply to a `scale!=NULL` setting with any other matrix representation that cannot be `fastpath`'d.