### PR TITLE
Update documentation to address CRAN note on lost braces

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ LinkingTo: Matrix
 Imports: stats, methods
 License: GPL-3
 BugReports: https://github.com/bwlewis/irlba/issues
-RoxygenNote: 5.0.1
+RoxygenNote: 7.3.2
 NeedsCompilation: yes
 Packaged: 2022-10-03 15:17:05 UTC; ripley
 Author: Jim Baglama [aut, cph],
@@ -25,3 +25,4 @@ Author: Jim Baglama [aut, cph],
 Maintainer: B. W. Lewis <blewis@illposed.net>
 Repository: CRAN
 Date/Publication: 2022-10-03 18:38:49 UTC
+Encoding: UTF-8

--- a/R/eigen.R
+++ b/R/eigen.R
@@ -1,4 +1,4 @@
-#' Find a few approximate largest eigenvalues and corresponding eigenvectors of a symmetric matrix.
+#' Find a few approximate largest eigenvalues and corresponding eigenvectors of a symmetric matrix
 #'
 #' Use \code{partial_eigen} to estimate a subset of the largest (most positive)
 #' eigenvalues and corresponding eigenvectors of a symmetric dense or sparse
@@ -13,7 +13,7 @@
 #'
 #' @return
 #' Returns a list with entries:
-#' \itemize{
+#' \describe{
 #'   \item{values}{ n approximate largest eigenvalues}
 #'   \item{vectors}{ n approximate corresponding eigenvectors}
 #' }

--- a/R/irlba.R
+++ b/R/irlba.R
@@ -1,5 +1,5 @@
 #' Find a few approximate singular values and corresponding
-#' singular vectors of a matrix.
+#' singular vectors of a matrix
 #'
 #' The augmented implicitly restarted Lanczos bidiagonalization algorithm
 #' (IRLBA) finds a few approximate largest (or, optionally, smallest) singular
@@ -108,18 +108,18 @@
 #'
 #' The function may generate the following warnings:
 #' \itemize{
-#'   \item{"did not converge--results might be invalid!; try increasing work or maxit"
+#'   \item "did not converge--results might be invalid!; try increasing work or maxit"
 #'   means that the algorithm didn't
 #'   converge -- this is potentially a serious problem and the returned results may not be valid. \code{irlba}
 #'   reports a warning here instead of an error so that you can inspect whatever is returned. If this
-#'   happens, carefully heed the warning and inspect the result. You may also try setting \code{fastpath=FALSE}.}
-#'   \item{"You're computing a large percentage of total singular values, standard svd might work better!"
+#'   happens, carefully heed the warning and inspect the result. You may also try setting \code{fastpath=FALSE}.
+#'   \item "You're computing a large percentage of total singular values, standard svd might work better!"
 #'     \code{irlba} is designed to efficiently compute a few of the largest singular values and associated
 #'      singular vectors of a matrix. The standard \code{svd} function will be more efficient for computing
-#'      large numbers of singular values than \code{irlba}.}
-#'    \item{"convergence criterion below machine epsilon" means that the product of \code{tol} and the
+#'      large numbers of singular values than \code{irlba}.
+#'   \item "convergence criterion below machine epsilon" means that the product of \code{tol} and the
 #'      largest estimated singular value is really small and the normal convergence criterion is only
-#'      met up to round off error.}
+#'      met up to round off error.
 #' }
 #' The function might return an error for several reasons including a situation when the starting
 #' vector \code{v} is near the null space of the matrix. In that case, try a different \code{v}.

--- a/R/prcomp.R
+++ b/R/prcomp.R
@@ -28,18 +28,18 @@
 #'
 #' @return
 #' A list with class "prcomp" containing the following components:
-#' \itemize{
-#'    \item{sdev} {the standard deviations of the principal components (i.e.,
+#' \describe{
+#'    \item{sdev}{the standard deviations of the principal components (i.e.,
 #'          the square roots of the eigenvalues of the
 #'          covariance/correlation matrix, though the calculation is
 #'          actually done with the singular values of the data matrix).}
-#'   \item{rotation} {the matrix of variable loadings (i.e., a matrix whose columns
+#'   \item{rotation}{the matrix of variable loadings (i.e., a matrix whose columns
 #'          contain the eigenvectors).}
-#'   \item {x} {if \code{retx} is \code{TRUE} the value of the rotated data (the centred
+#'   \item{x}{if \code{retx} is \code{TRUE} the value of the rotated data (the centred
 #'          (and scaled if requested) data multiplied by the \code{rotation}
 #'         matrix) is returned.  Hence, \code{cov(x)} is the diagonal matrix
 #'          \code{diag(sdev^2)}.}
-#'   \item{center, scale} {the centering and scaling used, or \code{FALSE}.}
+#'   \item{center, scale}{the centering and scaling used, or \code{FALSE}.}
 #' }
 #'
 #' @note
@@ -130,7 +130,7 @@ control that algorithm's convergence tolerance. See `?prcomp_irlba` for help.")
   ans
 }
 
-#' Summary method for truncated pca objects computed by \code{prcomp_irlba}.
+#' Summary method for truncated pca objects computed by \code{prcomp_irlba}
 #' @param object An object returned by \code{prcomp_irlba}.
 #' @param ... Optional arguments passed to \code{summary}.
 #' @method summary irlba_prcomp

--- a/R/ssvd.R
+++ b/R/ssvd.R
@@ -1,4 +1,4 @@
-#' Sparse regularized low-rank matrix approximation.
+#' Sparse regularized low-rank matrix approximation
 #'
 #' Estimate an \eqn{{\ell}1}{l1}-penalized
 #' singular value or principal components decomposition (SVD or PCA) that introduces sparsity in the
@@ -50,35 +50,35 @@
 #'
 #' @return
 #' A list containing the following components:
-#' \itemize{
-#'    \item{u} {regularized left singular vectors with orthonormal columns}
-#'    \item{d} {regularized upper-triangluar projection matrix so that \code{x \%*\% v == u \%*\% d}}
-#'    \item{v} {regularized, sparse right singular vectors with columns of unit norm}
-#'    \item{center, scale} {the centering and scaling used, if any}
-#'    \item{lambda} {the per-column regularization parameter found to obtain the desired sparsity}
-#'    \item{iter} {number of soft thresholding iterations}
-#'    \item{n} {value of input parameter \code{n}}
-#'    \item{alpha} {value of input parameter \code{alpha}}
+#' \describe{
+#'    \item{u}{regularized left singular vectors with orthonormal columns}
+#'    \item{d}{regularized upper-triangluar projection matrix so that \code{x \%*\% v == u \%*\% d}}
+#'    \item{v}{regularized, sparse right singular vectors with columns of unit norm}
+#'    \item{center, scale}{the centering and scaling used, if any}
+#'    \item{lambda}{the per-column regularization parameter found to obtain the desired sparsity}
+#'    \item{iter}{number of soft thresholding iterations}
+#'    \item{n}{value of input parameter \code{n}}
+#'    \item{alpha}{value of input parameter \code{alpha}}
 #' }
 #' @note
 #' Our \code{ssvd} implementation of the Shen-Huang method makes the following choices:
 #' \enumerate{
-#' \item{The l1 penalty is the only available penalty function. Other penalties may appear in the future.}
-#' \item{Given a desired number of nonzero elements in \code{v}, value(s) for the \eqn{\lambda}{lambda}
-#'       penalty are determined to achieve the sparsity goal subject to the parameter \code{alpha}.}
-#' \item{An experimental block implementation is used for results with rank greater than 1 (when \code{k > 1})
-#'       instead of the deflation method described in the reference.}
-#' \item{The choice of a penalty lambda associated with a given number of desired nonzero
+#' \item The l1 penalty is the only available penalty function. Other penalties may appear in the future.
+#' \item Given a desired number of nonzero elements in \code{v}, value(s) for the \eqn{\lambda}{lambda}
+#'       penalty are determined to achieve the sparsity goal subject to the parameter \code{alpha}.
+#' \item An experimental block implementation is used for results with rank greater than 1 (when \code{k > 1})
+#'       instead of the deflation method described in the reference.
+#' \item The choice of a penalty lambda associated with a given number of desired nonzero
 #'       components is not unique. The \code{alpha} parameter, a scalar between zero and one,
 #'       selects any possible value of lambda that produces the desired number of
 #'       nonzero entries. The default \code{alpha = 0} selects a penalized solution with
 #'       largest corresponding value of \code{d} in the 1-d case. Think of \code{alpha} as
-#'       fine-tuning of the penalty.}
-#' \item{Our method returns an upper-triangular matrix \code{d} when \code{k > 1} so
+#'       fine-tuning of the penalty.
+#' \item Our method returns an upper-triangular matrix \code{d} when \code{k > 1} so
 #'       that \code{x \%*\% v == u \%*\% d}. Non-zero
 #'       elements above the diagonal result from non-orthogonality of the \code{v} matrix,
 #'       providing a simple interpretation of cumulative information, or explained variance
-#'       in the PCA case, via the singular value decomposition of \code{d \%*\% t(v)}.}
+#'       in the PCA case, via the singular value decomposition of \code{d \%*\% t(v)}.
 #' }
 #'
 #' What if you have no idea for values of the argument \code{n} (the desired sparsity)?
@@ -103,8 +103,8 @@
 #'
 #' @references
 #' \itemize{
-#'   \item{Shen, Haipeng, and Jianhua Z. Huang. "Sparse principal component analysis via regularized low rank matrix approximation." Journal of multivariate analysis 99.6 (2008): 1015-1034.}
-#'   \item{Witten, Tibshirani and Hastie (2009) A penalized matrix decomposition, with applications to sparse principal components and canonical correlation analysis. _Biostatistics_ 10(3): 515-534.}
+#'   \item Shen, Haipeng, and Jianhua Z. Huang. "Sparse principal component analysis via regularized low rank matrix approximation." Journal of multivariate analysis 99.6 (2008): 1015-1034. 
+#'   \item Witten, Tibshirani and Hastie (2009) A penalized matrix decomposition, with applications to sparse principal components and canonical correlation analysis. _Biostatistics_ 10(3): 515-534.
 #' }
 #' @examples
 #'

--- a/R/svdr.R
+++ b/R/svdr.R
@@ -1,5 +1,5 @@
 #' Find a few approximate largest singular values and corresponding
-#' singular vectors of a matrix.
+#' singular vectors of a matrix
 #'
 #' The randomized method for truncated SVD by P. G. Martinsson and colleagues
 #' finds a few approximate largest singular values and corresponding

--- a/man/irlba.Rd
+++ b/man/irlba.Rd
@@ -3,12 +3,28 @@
 \name{irlba}
 \alias{irlba}
 \title{Find a few approximate singular values and corresponding
-singular vectors of a matrix.}
+singular vectors of a matrix}
 \usage{
-irlba(A, nv = 5, nu = nv, maxit = 1000, work = nv + 7, reorth = TRUE,
-  tol = 1e-05, v = NULL, right_only = FALSE, verbose = FALSE,
-  scale = NULL, center = NULL, shift = NULL, mult = NULL,
-  fastpath = TRUE, svtol = tol, smallest = FALSE, ...)
+irlba(
+  A,
+  nv = 5,
+  nu = nv,
+  maxit = 1000,
+  work = nv + 7,
+  reorth = TRUE,
+  tol = 1e-05,
+  v = NULL,
+  right_only = FALSE,
+  verbose = FALSE,
+  scale = NULL,
+  center = NULL,
+  shift = NULL,
+  mult = NULL,
+  fastpath = TRUE,
+  svtol = tol,
+  smallest = FALSE,
+  ...
+)
 }
 \arguments{
 \item{A}{numeric real- or complex-valued matrix or real-valued sparse matrix.}
@@ -136,18 +152,18 @@ subspace. See the examples.
 
 The function may generate the following warnings:
 \itemize{
-  \item{"did not converge--results might be invalid!; try increasing work or maxit"
+  \item "did not converge--results might be invalid!; try increasing work or maxit"
   means that the algorithm didn't
   converge -- this is potentially a serious problem and the returned results may not be valid. \code{irlba}
   reports a warning here instead of an error so that you can inspect whatever is returned. If this
-  happens, carefully heed the warning and inspect the result. You may also try setting \code{fastpath=FALSE}.}
-  \item{"You're computing a large percentage of total singular values, standard svd might work better!"
+  happens, carefully heed the warning and inspect the result. You may also try setting \code{fastpath=FALSE}.
+  \item "You're computing a large percentage of total singular values, standard svd might work better!"
     \code{irlba} is designed to efficiently compute a few of the largest singular values and associated
      singular vectors of a matrix. The standard \code{svd} function will be more efficient for computing
-     large numbers of singular values than \code{irlba}.}
-   \item{"convergence criterion below machine epsilon" means that the product of \code{tol} and the
+     large numbers of singular values than \code{irlba}.
+  \item "convergence criterion below machine epsilon" means that the product of \code{tol} and the
      largest estimated singular value is really small and the normal convergence criterion is only
-     met up to round off error.}
+     met up to round off error.
 }
 The function might return an error for several reasons including a situation when the starting
 vector \code{v} is near the null space of the matrix. In that case, try a different \code{v}.
@@ -206,4 +222,3 @@ Baglama, James, and Lothar Reichel. "Augmented implicitly restarted Lanczos bidi
 \seealso{
 \code{\link{svd}}, \code{\link{prcomp}}, \code{\link{partial_eigen}}, \code{\link{svdr}}
 }
-

--- a/man/partial_eigen.Rd
+++ b/man/partial_eigen.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/eigen.R
 \name{partial_eigen}
 \alias{partial_eigen}
-\title{Find a few approximate largest eigenvalues and corresponding eigenvectors of a symmetric matrix.}
+\title{Find a few approximate largest eigenvalues and corresponding eigenvectors of a symmetric matrix}
 \usage{
 partial_eigen(x, n = 5, symmetric = TRUE, ...)
 }
@@ -19,7 +19,7 @@ eigenvectors of \code{t(x) \%*\% x} instead.}
 }
 \value{
 Returns a list with entries:
-\itemize{
+\describe{
   \item{values}{ n approximate largest eigenvalues}
   \item{vectors}{ n approximate corresponding eigenvectors}
 }
@@ -63,4 +63,3 @@ Augmented Implicitly Restarted Lanczos Bidiagonalization Methods, J. Baglama and
 \seealso{
 \code{\link{eigen}}, \code{\link{irlba}}
 }
-

--- a/man/prcomp_irlba.Rd
+++ b/man/prcomp_irlba.Rd
@@ -37,18 +37,18 @@ equal the number of columns of \code{x} can be supplied.}
 }
 \value{
 A list with class "prcomp" containing the following components:
-\itemize{
-   \item{sdev} {the standard deviations of the principal components (i.e.,
+\describe{
+   \item{sdev}{the standard deviations of the principal components (i.e.,
          the square roots of the eigenvalues of the
          covariance/correlation matrix, though the calculation is
          actually done with the singular values of the data matrix).}
-  \item{rotation} {the matrix of variable loadings (i.e., a matrix whose columns
+  \item{rotation}{the matrix of variable loadings (i.e., a matrix whose columns
          contain the eigenvectors).}
-  \item {x} {if \code{retx} is \code{TRUE} the value of the rotated data (the centred
+  \item{x}{if \code{retx} is \code{TRUE} the value of the rotated data (the centred
          (and scaled if requested) data multiplied by the \code{rotation}
         matrix) is returned.  Hence, \code{cov(x)} is the diagonal matrix
          \code{diag(sdev^2)}.}
-  \item{center, scale} {the centering and scaling used, or \code{FALSE}.}
+  \item{center, scale}{the centering and scaling used, or \code{FALSE}.}
 }
 }
 \description{
@@ -83,4 +83,3 @@ summary(p2)
 \seealso{
 \code{\link{prcomp}}
 }
-

--- a/man/ssvd.Rd
+++ b/man/ssvd.Rd
@@ -2,10 +2,20 @@
 % Please edit documentation in R/ssvd.R
 \name{ssvd}
 \alias{ssvd}
-\title{Sparse regularized low-rank matrix approximation.}
+\title{Sparse regularized low-rank matrix approximation}
 \usage{
-ssvd(x, k = 1, n = 2, maxit = 500, tol = 0.001, center = FALSE,
-  scale. = FALSE, alpha = 0, tsvd = NULL, ...)
+ssvd(
+  x,
+  k = 1,
+  n = 2,
+  maxit = 500,
+  tol = 0.001,
+  center = FALSE,
+  scale. = FALSE,
+  alpha = 0,
+  tsvd = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{A numeric real- or complex-valued matrix or real-valued sparse matrix.}
@@ -48,15 +58,15 @@ to perform a regularized sparse PCA.}
 }
 \value{
 A list containing the following components:
-\itemize{
-   \item{u} {regularized left singular vectors with orthonormal columns}
-   \item{d} {regularized upper-triangluar projection matrix so that \code{x \%*\% v == u \%*\% d}}
-   \item{v} {regularized, sparse right singular vectors with columns of unit norm}
-   \item{center, scale} {the centering and scaling used, if any}
-   \item{lambda} {the per-column regularization parameter found to obtain the desired sparsity}
-   \item{iter} {number of soft thresholding iterations}
-   \item{n} {value of input parameter \code{n}}
-   \item{alpha} {value of input parameter \code{alpha}}
+\describe{
+   \item{u}{regularized left singular vectors with orthonormal columns}
+   \item{d}{regularized upper-triangluar projection matrix so that \code{x \%*\% v == u \%*\% d}}
+   \item{v}{regularized, sparse right singular vectors with columns of unit norm}
+   \item{center, scale}{the centering and scaling used, if any}
+   \item{lambda}{the per-column regularization parameter found to obtain the desired sparsity}
+   \item{iter}{number of soft thresholding iterations}
+   \item{n}{value of input parameter \code{n}}
+   \item{alpha}{value of input parameter \code{alpha}}
 }
 }
 \description{
@@ -84,22 +94,22 @@ Unlike standard SVD or PCA, the columns of the returned \code{v} when \code{k > 
 \note{
 Our \code{ssvd} implementation of the Shen-Huang method makes the following choices:
 \enumerate{
-\item{The l1 penalty is the only available penalty function. Other penalties may appear in the future.}
-\item{Given a desired number of nonzero elements in \code{v}, value(s) for the \eqn{\lambda}{lambda}
-      penalty are determined to achieve the sparsity goal subject to the parameter \code{alpha}.}
-\item{An experimental block implementation is used for results with rank greater than 1 (when \code{k > 1})
-      instead of the deflation method described in the reference.}
-\item{The choice of a penalty lambda associated with a given number of desired nonzero
+\item The l1 penalty is the only available penalty function. Other penalties may appear in the future.
+\item Given a desired number of nonzero elements in \code{v}, value(s) for the \eqn{\lambda}{lambda}
+      penalty are determined to achieve the sparsity goal subject to the parameter \code{alpha}.
+\item An experimental block implementation is used for results with rank greater than 1 (when \code{k > 1})
+      instead of the deflation method described in the reference.
+\item The choice of a penalty lambda associated with a given number of desired nonzero
       components is not unique. The \code{alpha} parameter, a scalar between zero and one,
       selects any possible value of lambda that produces the desired number of
       nonzero entries. The default \code{alpha = 0} selects a penalized solution with
       largest corresponding value of \code{d} in the 1-d case. Think of \code{alpha} as
-      fine-tuning of the penalty.}
-\item{Our method returns an upper-triangular matrix \code{d} when \code{k > 1} so
+      fine-tuning of the penalty.
+\item Our method returns an upper-triangular matrix \code{d} when \code{k > 1} so
       that \code{x \%*\% v == u \%*\% d}. Non-zero
       elements above the diagonal result from non-orthogonality of the \code{v} matrix,
       providing a simple interpretation of cumulative information, or explained variance
-      in the PCA case, via the singular value decomposition of \code{d \%*\% t(v)}.}
+      in the PCA case, via the singular value decomposition of \code{d \%*\% t(v)}.
 }
 
 What if you have no idea for values of the argument \code{n} (the desired sparsity)?
@@ -167,8 +177,7 @@ par(oldpar)
 }
 \references{
 \itemize{
-  \item{Shen, Haipeng, and Jianhua Z. Huang. "Sparse principal component analysis via regularized low rank matrix approximation." Journal of multivariate analysis 99.6 (2008): 1015-1034.}
-  \item{Witten, Tibshirani and Hastie (2009) A penalized matrix decomposition, with applications to sparse principal components and canonical correlation analysis. _Biostatistics_ 10(3): 515-534.}
+  \item Shen, Haipeng, and Jianhua Z. Huang. "Sparse principal component analysis via regularized low rank matrix approximation." Journal of multivariate analysis 99.6 (2008): 1015-1034. 
+  \item Witten, Tibshirani and Hastie (2009) A penalized matrix decomposition, with applications to sparse principal components and canonical correlation analysis. _Biostatistics_ 10(3): 515-534.
 }
 }
-

--- a/man/summary.irlba_prcomp.Rd
+++ b/man/summary.irlba_prcomp.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/prcomp.R
 \name{summary.irlba_prcomp}
 \alias{summary.irlba_prcomp}
-\title{Summary method for truncated pca objects computed by \code{prcomp_irlba}.}
+\title{Summary method for truncated pca objects computed by \code{prcomp_irlba}}
 \usage{
 \method{summary}{irlba_prcomp}(object, ...)
 }
@@ -12,6 +12,5 @@
 \item{...}{Optional arguments passed to \code{summary}.}
 }
 \description{
-Summary method for truncated pca objects computed by \code{prcomp_irlba}.
+Summary method for truncated pca objects computed by \code{prcomp_irlba}
 }
-

--- a/man/svdr.Rd
+++ b/man/svdr.Rd
@@ -3,10 +3,18 @@
 \name{svdr}
 \alias{svdr}
 \title{Find a few approximate largest singular values and corresponding
-singular vectors of a matrix.}
+singular vectors of a matrix}
 \usage{
-svdr(x, k, tol = 1e-05, it = 100L, extra = min(10L, dim(x) - k),
-  center = NULL, Q = NULL, return.Q = FALSE)
+svdr(
+  x,
+  k,
+  tol = 1e-05,
+  it = 100L,
+  extra = min(10L, dim(x) - k),
+  center = NULL,
+  Q = NULL,
+  return.Q = FALSE
+)
 }
 \arguments{
 \item{x}{numeric real- or complex-valued matrix or real-valued sparse matrix.}
@@ -111,4 +119,3 @@ approximate matrix decompositions N. Halko, P. G. Martinsson, J. Tropp. Sep. 200
 \seealso{
 \code{\link{irlba}}, \code{\link{svd}}, \code{rsvd} in the rsvd package
 }
-


### PR DESCRIPTION
```
Check Details

Version: 2.3.5.1
Check: Rd files
Result: NOTE 
  checkRd: (-1) partial_eigen.Rd:23: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) partial_eigen.Rd:24: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) prcomp_irlba.Rd:41-44: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) prcomp_irlba.Rd:45-46: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) prcomp_irlba.Rd:47-50: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) prcomp_irlba.Rd:51: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) ssvd.Rd:52: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) ssvd.Rd:53: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) ssvd.Rd:54: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) ssvd.Rd:55: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) ssvd.Rd:56: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) ssvd.Rd:57: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) ssvd.Rd:58: Lost braces in \itemize; \value handles \item{}{} directly
  checkRd: (-1) ssvd.Rd:59: Lost braces in \itemize; \value handles \item{}{} directly
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/irlba-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/irlba-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/irlba-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/irlba-00check.html), [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/irlba-00check.html), [r-patched-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-patched-linux-x86_64/irlba-00check.html), [r-release-linux-x86_64](https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/irlba-00check.html), [r-release-macos-arm64](https://www.r-project.org/nosvn/R.check/r-release-macos-arm64/irlba-00check.html), [r-release-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-release-macos-x86_64/irlba-00check.html), [r-release-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-release-windows-x86_64/irlba-00check.html), [r-oldrel-macos-arm64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-arm64/irlba-00check.html), [r-oldrel-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-x86_64/irlba-00check.html), [r-oldrel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-oldrel-windows-x86_64/irlba-00check.html)
```